### PR TITLE
Add arm simulation (incomplete)

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -82,4 +82,26 @@ public final class Constants {
     public static int kLEDLightsChannel = 9;
     public static int kLEDLightsLength = 40;
   }
+
+  public static class SimConstants {
+    // Winch
+    public static double kTotalStringLenMeters = 1;
+    public static double kCurrentLenSpooled = 0.25;
+    public static double kwinchSimGearRatio = 20.0; // 20:1
+
+    // Arm
+    public static double karmLengthFromEdgeToPivot = 0.25;
+    public static double karmHeightFromWinchToPivotPoint = 0.75;
+    
+    public static double karmHeightFromWinchToPivotPoint_Min = 0.1;
+    public static double karmLengthFromEdgeToPivot_Min = 0.1;
+    public static double karmEncoderRotationsOffset = 0.56;
+
+    public static double kdeltaRotationsBeforeBroken = 0;
+    public static double kgrabberBreaksIfOpenBelowThisLimit = 0.60;
+
+    // We use the same constants for upper and lower limits as physical arm:
+    //  kWinchEncoderUpperLimit = 0.78;
+    //  kWinchEncoderLowerLimit = 0.56;
+  }
 }

--- a/src/main/java/frc/robot/Simulation/ArmSimulation.java
+++ b/src/main/java/frc/robot/Simulation/ArmSimulation.java
@@ -5,10 +5,13 @@ import edu.wpi.first.wpilibj.simulation.DutyCycleEncoderSim;
 public class ArmSimulation {
   private WinchSimulation m_winchSimulation;
   private DutyCycleEncoderSim m_winchAbsoluteEncoderSim;
-  private double m_topRotationsLimit;
-  private double m_bottomRotationsLimit;
-  private double m_deltaRotationsBeforeBroken;
-  private double m_grabberBreaksIfOpenBelowThisLimit;
+  private double m_topSignedDegreesLimit;
+  private double m_bottomSignedDegreesLimit;
+  private double m_grabberBreaksIfOpenBelowSignedDegreesLimit;
+  private double m_encoderRotationsOffset;
+  private boolean m_IsBroken;
+
+  private CalcArmAngle m_calcArmAngle;
 
   // Constructor
   public ArmSimulation(
@@ -17,49 +20,136 @@ public class ArmSimulation {
     double topRotationsLimit,
     double bottomRotationsLimit,
     double deltaRotationsBeforeBroken,
-    double grabberBreaksIfOpenBelowThisLimit) {
+    double grabberBreaksIfOpenBelowThisLimit,
+    double heightFromWinchToPivotPoint,
+    double armLengthFromEdgeToPivot,
+    double armLengthFromEdgeToPivot_Min,
+    double encoderRotationsOffset) {
 
     if (winchSimulation == null) {
       throw new IllegalArgumentException("winchSimulation");
     }
 
-    if (bottomRotationsLimit > 1 || bottomRotationsLimit < 0 || topRotationsLimit > 1 || topRotationsLimit < 0) {
-      throw new IllegalArgumentException("bottomRotationsLimit and topRotationsLimit must be <=1");
+    if (armLengthFromEdgeToPivot < armLengthFromEdgeToPivot_Min) {
+      throw new IllegalArgumentException("armLengthFromEdgeToPivot needs to be at least "
+        + armLengthFromEdgeToPivot_Min
+        + " meters, otherwise the arm cant be pivoted");
     }
 
-    if (deltaRotationsBeforeBroken > 1 || deltaRotationsBeforeBroken < 0) {
-      throw new IllegalArgumentException("deltaRotationsBeforeBroken must be <=1");
+    if (encoderRotationsOffset < 0 || encoderRotationsOffset >= 1) {
+      throw new IllegalArgumentException("encoderRotationsOffset must be between 0 and 1");
     }
 
-    if (topRotationsLimit <= bottomRotationsLimit) {
-      throw new IllegalArgumentException("topRotationsLimit must be greater than bottomRotationsLimit");
+    m_topSignedDegreesLimit = toNonOffsetSignedDegrees(topRotationsLimit + deltaRotationsBeforeBroken, encoderRotationsOffset);
+    m_bottomSignedDegreesLimit = toNonOffsetSignedDegrees(bottomRotationsLimit - deltaRotationsBeforeBroken, encoderRotationsOffset);
+    m_grabberBreaksIfOpenBelowSignedDegreesLimit = toNonOffsetSignedDegrees(grabberBreaksIfOpenBelowThisLimit, encoderRotationsOffset);
+
+    if (!isInRightHalfPlane(m_topSignedDegreesLimit)) {
+      throw new IllegalArgumentException("m_topSignedDegreesLimit must be between -90 and 90");
     }
 
-    if (topRotationsLimit + deltaRotationsBeforeBroken > 1) {
-      throw new IllegalArgumentException("topRotationsLimit + deltaRotationsBeforeBroken must be <=1");
+    if (!isInRightHalfPlane(m_bottomSignedDegreesLimit)) {
+      throw new IllegalArgumentException("m_bottomSignedDegreesLimit must be between -90 and 90");
     }
 
-    if (bottomRotationsLimit - deltaRotationsBeforeBroken < 0) {
-      throw new IllegalArgumentException("bottomRotationsLimit - deltaRotationsBeforeBroken must be >= 0");
+    if (!isInRightHalfPlane(m_grabberBreaksIfOpenBelowSignedDegreesLimit)) {
+      throw new IllegalArgumentException("m_grabberBreaksIfOpenBelowSignedDegreesLimit must be between -90 and 90");
     }
 
-    if (grabberBreaksIfOpenBelowThisLimit <= bottomRotationsLimit || grabberBreaksIfOpenBelowThisLimit >= topRotationsLimit) {
-      throw new IllegalArgumentException("grabberBreaksIfOpenBelowThisLimit must be between bottomRotationsLimit and topRotationsLimit");
+    if (m_topSignedDegreesLimit <= m_bottomSignedDegreesLimit) {
+      throw new IllegalArgumentException("m_topSignedDegreesLimit must be > m_bottomSignedDegreesLimit");
+    }
+
+    if (m_grabberBreaksIfOpenBelowSignedDegreesLimit >= m_topSignedDegreesLimit ||
+        m_grabberBreaksIfOpenBelowSignedDegreesLimit <= m_bottomSignedDegreesLimit) {
+      throw new IllegalArgumentException("m_grabberBreaksIfOpenBelowSignedDegreesLimit must be between m_topSignedDegreesLimit and m_bottomSignedDegreesLimit");
     }
 
     m_winchSimulation = winchSimulation;
     m_winchAbsoluteEncoderSim = winchAbsoluteEncoderSim;
-    m_topRotationsLimit = topRotationsLimit;
-    m_bottomRotationsLimit = bottomRotationsLimit;
-    m_deltaRotationsBeforeBroken = deltaRotationsBeforeBroken;
-    m_grabberBreaksIfOpenBelowThisLimit = grabberBreaksIfOpenBelowThisLimit;
+    m_encoderRotationsOffset = encoderRotationsOffset;
+    m_IsBroken = false;
+
+    m_calcArmAngle = new CalcArmAngle(heightFromWinchToPivotPoint, armLengthFromEdgeToPivot);
+
+    // Forces the absolute encoder to show the correct position
+    UpdateAbsoluteEncoderPosition();
+  }
+
+  public boolean GetIsBroken() {
+    return m_IsBroken;
   }
 
   public void periodic() {
   }
 
+  public static double OffsetArmRotationPosition(double position, double offset) {
+    double positionWithOffset = position + offset;
+    return positionWithOffset - Math.floor(positionWithOffset);
+  }
+
+  public static double toSignedDegrees(double degrees) {
+    double signedDegrees = degrees % 360;
+
+    if (signedDegrees > 180) {
+        signedDegrees -= 360;
+    } else if (signedDegrees < -180) {
+        signedDegrees += 360;
+    }
+    return signedDegrees;
+  }
+
+  public static double toNonOffsetSignedDegrees(double position, double offset) {
+    double positionWithoutOffset = OffsetArmRotationPosition(position, -1 * offset);
+    double degreesWithoutOffset = positionWithoutOffset * 360;
+    return toSignedDegrees(degreesWithoutOffset);
+  }
+
+  public static boolean isInRightHalfPlane(double signedDegrees) {
+      return signedDegrees >= -90 && signedDegrees <= 90;
+  }
+
+  private void UpdateAbsoluteEncoderPosition()
+  {
+    double newStringLen;
+    double newAbsoluteEncoderPosition;
+
+    // If the arm is broken, there's nothing to update
+    if (m_IsBroken) {
+      return;
+    }
+
+    newStringLen = m_winchSimulation.GetStringExtendedLen();
+    newAbsoluteEncoderPosition = m_calcArmAngle.GetRotationsForStringLength(newStringLen);
+
+    // Check if we got back that string length was invalid
+    if (newAbsoluteEncoderPosition == -1) {
+      System.out.println("ARM: Angle is out of bounds, needs to be between 0 - 90");
+      m_IsBroken = true;
+      return;
+    }
+
+    if (newAbsoluteEncoderPosition > m_topSignedDegreesLimit) {
+      System.out.println("ARM: Angle is above top limit of " + m_topSignedDegreesLimit);
+      m_IsBroken = true;
+      return;
+    }
+
+    if (newAbsoluteEncoderPosition < m_bottomSignedDegreesLimit) {
+      System.out.println("ARM: Angle is below limit of " + m_bottomSignedDegreesLimit);
+      m_IsBroken = true;
+      return;
+    }
+
+    double newOffsetAbsoluteEncoderPosition = OffsetArmRotationPosition(
+      newAbsoluteEncoderPosition,
+      m_encoderRotationsOffset);
+
+    m_winchAbsoluteEncoderSim.set(newOffsetAbsoluteEncoderPosition);
+  }
+
   public void simulationPeriodic() {
-    // $TODO UpdateNewLenSpooled();
+    UpdateAbsoluteEncoderPosition();
   }
 }
 

--- a/src/main/java/frc/robot/Simulation/WinchSimulation.java
+++ b/src/main/java/frc/robot/Simulation/WinchSimulation.java
@@ -75,6 +75,7 @@ public class WinchSimulation {
     // Take a snapshot of current DCMotor position
     m_initialMotorRotations = m_motorEncoderSim.getPosition();
 
+    // Call this to initialize m_currentLenSpooled
     UpdateNewLenSpooled();
   }
 

--- a/src/main/java/frc/robot/Subsystems/ArmSystem.java
+++ b/src/main/java/frc/robot/Subsystems/ArmSystem.java
@@ -34,7 +34,7 @@ public class ArmSystem extends SubsystemBase{
 
     public ArmSystem(int armWinchChannel, int armExtenderChannel, XboxController m_controller, double m_deadband, boolean squareInputs, double maxOutputWinch) {
         m_armWinch = new CANSparkMax(armWinchChannel, MotorType.kBrushless);
-        m_armWinch.setSmartCurrentLimit(20);
+        m_armWinch.setSmartCurrentLimit(20); // $TODO - For simulation, test that smart limits actually work when I set a value on SparkMax
         m_armExtender = new CANSparkMax(armExtenderChannel, MotorType.kBrushless);
         m_armExtender.setSmartCurrentLimit(20);
         m_armExtender.setInverted(false);

--- a/src/main/java/frc/robot/Subsystems/DutyCycleEncoderSim2.java
+++ b/src/main/java/frc/robot/Subsystems/DutyCycleEncoderSim2.java
@@ -1,0 +1,31 @@
+package frc.robot.Subsystems;
+
+import edu.wpi.first.hal.SimDouble;
+import edu.wpi.first.wpilibj.DutyCycleEncoder;
+import edu.wpi.first.wpilibj.simulation.DutyCycleEncoderSim;
+import edu.wpi.first.wpilibj.simulation.SimDeviceSim;
+
+// DutyCycleEncoderSim class sets the "position" as a double, so that the base DutyCycleEncoder class
+// can read it.  Unfortunately, it doesn't set the "absPosition" as a double too, even though
+// some Robot code accesses the absolute position by calling DutyCycleEncoder->getAbsolutePosition().
+// So this wrapper adds that functionality
+public class DutyCycleEncoderSim2 extends DutyCycleEncoderSim{
+  private final SimDouble m_simAbsolutePosition;
+
+  // Constructor
+  public DutyCycleEncoderSim2(DutyCycleEncoder encoder) {  
+    // FIRST, we call superclass
+    super(encoder);
+
+    SimDeviceSim wrappedSimDevice =
+        new SimDeviceSim("DutyCycle:DutyCycleEncoder" + "[" + encoder.getSourceChannel() + "]");
+        m_simAbsolutePosition = wrappedSimDevice.getDouble("absPosition");
+  }
+
+  @Override
+  public void set(double turns) {
+    super.set(turns);
+
+    m_simAbsolutePosition.set(turns);
+  }
+}

--- a/src/test/java/frc/robot/Simulation/ArmSimulationTest.java
+++ b/src/test/java/frc/robot/Simulation/ArmSimulationTest.java
@@ -4,6 +4,7 @@ import edu.wpi.first.hal.HAL;
 import frc.robot.Subsystems.RelativeEncoderSim;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj.simulation.DutyCycleEncoderSim;
+import frc.robot.Subsystems.DutyCycleEncoderSim2;
 import frc.robot.Simulation.WinchSimulation.StringOrientation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
@@ -14,15 +15,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import frc.robot.Constants;
 
 public class ArmSimulationTest {
-    private final double m_armTopRotationsLimit = 0.78;
-    private final double m_armBottomRotationsLimit = 0.56;
-    private final double m_armDeltaRotationsBeforeBroken = 0.02;
-    private final double m_grabberBreaksIfOpenBelowThisLimit = 0.60;
+    private final double m_armTopRotationsLimit = 0.25;
+    private final double m_armBottomRotationsLimit = 0.75;
+    private final double m_armDeltaRotationsBeforeBroken = 0;
+    private final double m_grabberBreaksIfOpenBelowThisLimit = 0.80;
     private final double m_winchSpoolDiameterMeters = 0.01; // (1 centimeter)
     private final double m_winchTotalStringLenMeters = 5;
-    private final double m_winchInitialLenSpooled = 1;
+    private final double m_winchInitialLenSpooled = 4;
     private final StringOrientation m_winchInitialStringOrientation = StringOrientation.BackOfRobot;
     private final boolean m_winchinvertMotor = false;
+    private final double m_armHeightFromWinchToPivotPoint = 1;
+    private final double m_armLengthFromEdgeToPivot = 0.5; // The pivot is halfway down the arm
+    private final double m_armLengthFromEdgeToPivot_Min = 0.1;
+    private final double m_encoderPositionOffsetRotations = 0;
+
+    private final double toleranceDegrees = 2;
 
     private WinchSimulation m_winchSimulation;
     private RelativeEncoderSim m_winchRelEncoderSim;
@@ -44,7 +51,7 @@ public class ArmSimulationTest {
         m_winchinvertMotor);
 
       m_winchAbsoluteEncoder = new DutyCycleEncoder(Constants.OperatorConstants.kAbsoluteEncoderWinchChannel);
-      m_winchAbsoluteEncoderSim = new DutyCycleEncoderSim(m_winchAbsoluteEncoder);
+      m_winchAbsoluteEncoderSim = new DutyCycleEncoderSim2(m_winchAbsoluteEncoder);
     }
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
@@ -64,9 +71,14 @@ public class ArmSimulationTest {
         m_armTopRotationsLimit,
         m_armBottomRotationsLimit,
         m_armDeltaRotationsBeforeBroken,
-        m_grabberBreaksIfOpenBelowThisLimit);
+        m_grabberBreaksIfOpenBelowThisLimit,
+        m_armHeightFromWinchToPivotPoint,
+        m_armLengthFromEdgeToPivot,
+        m_armLengthFromEdgeToPivot_Min,
+        m_encoderPositionOffsetRotations);
 
       assertTrue(tempArmSimulation != null);
+      assertTrue(!tempArmSimulation.GetIsBroken() && !m_winchSimulation.GetIsBroken());
     }
 
     @Test
@@ -78,60 +90,209 @@ public class ArmSimulationTest {
           m_armTopRotationsLimit,
           m_armBottomRotationsLimit,
           m_armDeltaRotationsBeforeBroken,
-          m_grabberBreaksIfOpenBelowThisLimit);
+          m_grabberBreaksIfOpenBelowThisLimit,
+          m_armHeightFromWinchToPivotPoint,
+          m_armLengthFromEdgeToPivot,
+          m_armLengthFromEdgeToPivot_Min,
+          m_encoderPositionOffsetRotations);
       });
     }
 
-    @Test
-    public void BottomLimitMinusDeltaLessThanZeroShouldThrowException() {
-      assertThrows(IllegalArgumentException.class, () -> {
-        ArmSimulation tempArmSimulation = new ArmSimulation(
-          m_winchSimulation,
-          m_winchAbsoluteEncoderSim,
-          m_armTopRotationsLimit,
-          0.01,
-          0.02,
-          m_grabberBreaksIfOpenBelowThisLimit);
-      });
-    }
+  public void CreateWithNDegreeArm_Helper(double backArmAbovePivot, double expectedDegrees, boolean expectArmBroken) {
+    double lengthStringExtended = m_armHeightFromWinchToPivotPoint + backArmAbovePivot;
+    double winchInitialLenSpooled = m_winchTotalStringLenMeters - lengthStringExtended;
 
-    @Test
-    public void TopLimitPlusDeltaGreaterThanOneShouldThrowException() {
-      assertThrows(IllegalArgumentException.class, () -> {
-        ArmSimulation tempArmSimulation = new ArmSimulation(
-          m_winchSimulation,
-          m_winchAbsoluteEncoderSim,
-          0.99,
-          m_armBottomRotationsLimit,
-          0.02,
-          m_grabberBreaksIfOpenBelowThisLimit);
-      });
-    }
+    WinchSimulation tempwinchSimulation = new WinchSimulation(
+      m_winchRelEncoderSim,
+      m_winchSpoolDiameterMeters,
+      m_winchTotalStringLenMeters,
+      winchInitialLenSpooled, // this is the value we're setting to make arm level
+      m_winchInitialStringOrientation,
+      m_winchinvertMotor);
 
-    @Test
-    public void BottomLimitMinusDeltaEqualToZeroShouldSucceed() {
-      ArmSimulation tempArmSimulation = new ArmSimulation(
-        m_winchSimulation,
-        m_winchAbsoluteEncoderSim,
-        m_armTopRotationsLimit,
-        0.01,
-        0.01,
-        m_grabberBreaksIfOpenBelowThisLimit);
+    ArmSimulation tempArmSimulation = new ArmSimulation(
+      tempwinchSimulation,
+      m_winchAbsoluteEncoderSim,
+      m_armTopRotationsLimit,
+      m_armBottomRotationsLimit,
+      m_armDeltaRotationsBeforeBroken,
+      m_grabberBreaksIfOpenBelowThisLimit,
+      m_armHeightFromWinchToPivotPoint,
+      m_armLengthFromEdgeToPivot,
+      m_armLengthFromEdgeToPivot_Min,
+      m_encoderPositionOffsetRotations);
 
       assertTrue(tempArmSimulation != null);
-    }
+      assertTrue(!tempwinchSimulation.GetIsBroken());
 
-    @Test
-    public void TopLimitPlusDeltaEqualToOneShouldSucceed() {
-      ArmSimulation tempArmSimulation = new ArmSimulation(
-        m_winchSimulation,
-        m_winchAbsoluteEncoderSim,
-        0.99,
-        m_armBottomRotationsLimit,
-        0.01,
-        m_grabberBreaksIfOpenBelowThisLimit);
+      if (expectArmBroken) {
+        assertTrue(tempArmSimulation.GetIsBroken());
+      }
+      else {
+        assertTrue(!tempArmSimulation.GetIsBroken()); 
+        assertEquals(m_winchAbsoluteEncoder.get() * 360, expectedDegrees, toleranceDegrees);
+      }
+  }
 
+
+  @Test
+  public void CreateWithLevelArmShouldSucceed() {
+    CreateWithNDegreeArm_Helper(0, 0, false);
+  }
+
+  @Test
+  public void CreateWith45DegreeArmShouldSucceed() {
+    CreateWithNDegreeArm_Helper(-0.35355, 45, false);
+  }
+
+  @Test
+  public void CreateWith30DegreeArmShouldSucceed() {
+    CreateWithNDegreeArm_Helper(-0.25, 30, false);
+  }
+
+  @Test
+  public void CreateWith90DegreeArmShouldSucceed() {
+    CreateWithNDegreeArm_Helper(-0.5, 90, false);
+  }
+
+  @Test
+  public void CreateWithNegative90DegreeArmShouldSucceed() {
+    CreateWithNDegreeArm_Helper(0.5, 360 - 90, false);
+  }
+
+  @Test
+  public void CreateWith91DegreeArmShouldFail() {
+    double amountBeyondLimit = 0.0001;
+
+    CreateWithNDegreeArm_Helper(-0.5 - amountBeyondLimit, 91, true);
+  }
+
+  @Test
+  public void CreateWithNegative91DegreeArmShouldFail() {
+    double amountBeyondLimit = 0.0001;
+
+    CreateWithNDegreeArm_Helper(0.5 + amountBeyondLimit, 360 - 91, true);
+  }
+
+  @Test
+  public void CreateWithNegative45DegreeArmShouldSucceed() {
+    CreateWithNDegreeArm_Helper(0.35355, 360 - 45, false);
+  }
+
+  // Sometimes, the absolute encoder is offset, and 0 isn't level    
+  @Test
+  public void CreateWithOffsetShouldSucceed() {
+    double lengthStringExtended = m_armHeightFromWinchToPivotPoint  - 0.35355;
+    double winchInitialLenSpooled = m_winchTotalStringLenMeters - lengthStringExtended;
+    double expectedDegrees = 45 + 90;
+    double offsetRotations = 0.25;
+
+    WinchSimulation tempwinchSimulation = new WinchSimulation(
+      m_winchRelEncoderSim,
+      m_winchSpoolDiameterMeters,
+      m_winchTotalStringLenMeters,
+      winchInitialLenSpooled, // this is the value we're setting to make arm level
+      m_winchInitialStringOrientation,
+      m_winchinvertMotor);
+
+    ArmSimulation tempArmSimulation = new ArmSimulation(
+      tempwinchSimulation,
+      m_winchAbsoluteEncoderSim,
+      m_armTopRotationsLimit + offsetRotations,
+      m_armBottomRotationsLimit + offsetRotations,
+      m_armDeltaRotationsBeforeBroken,
+      m_grabberBreaksIfOpenBelowThisLimit + offsetRotations,
+      m_armHeightFromWinchToPivotPoint,
+      m_armLengthFromEdgeToPivot,
+      m_armLengthFromEdgeToPivot_Min,
+      offsetRotations);
+    
       assertTrue(tempArmSimulation != null);
-    }
+      assertTrue(!tempwinchSimulation.GetIsBroken());
+      assertTrue(!tempArmSimulation.GetIsBroken()); 
+      assertEquals(m_winchAbsoluteEncoder.get() * 360, expectedDegrees, toleranceDegrees);
+  }
+
+  @Test
+  public void Offset0ArmRotationBy180DegreesShouldWork() {
+    double position = 0;
+    double offset = 0.5; //180
+    double expectedResult = 0.5;
+
+    double actualResult = ArmSimulation.OffsetArmRotationPosition(position, offset);
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void Offset90ArmRotationBy180DegreesShouldWork() {
+    double position = 0.25;
+    double offset = 0.5; //180
+    double expectedResult = 0.75;
+
+    double actualResult = ArmSimulation.OffsetArmRotationPosition(position, offset);
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void Offset216ArmRotationBy180DegreesShouldWork() {
+    double position = 0.6;
+    double offset = 0.5; //180
+    double expectedResult = 0.1;
+    double tolerance = 0.00001;
+
+    double actualResult = ArmSimulation.OffsetArmRotationPosition(position, offset);
+    assertEquals(expectedResult, actualResult, tolerance);
+  }
+
+  @Test
+  public void Offset180ArmRotationByNegative90DegreesShouldWork() {
+    double position = 0.5;
+    double offset = -0.25; //90
+    double expectedResult = 0.25;
+
+    double actualResult = ArmSimulation.OffsetArmRotationPosition(position, offset);
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void toSignedDegreesTestZeroDegrees() {
+      double input = 0;
+      double expected = 0;
+      assertEquals(expected, ArmSimulation.toSignedDegrees(input), 0.001);
+  }
+
+  @Test
+  public void toSignedDegreesTestPositiveDegrees() {
+      double input = 45;
+      double expected = 45;
+      assertEquals(expected, ArmSimulation.toSignedDegrees(input), 0.001);
+  }
+
+  @Test
+  public void toSignedDegreesTestNegativeDegrees() {
+      double input = -45;
+      double expected = -45;
+      assertEquals(expected, ArmSimulation.toSignedDegrees(input), 0.001);
+  }
+
+  @Test
+  public void toSignedDegreesTestBelowAxis() {
+      double input = 350;
+      double expected = -10;
+      assertEquals(expected, ArmSimulation.toSignedDegrees(input), 0.001);
+  }
+
+  @Test
+  public void toSignedDegreesTestWrapAroundPositiveDegrees() {
+      double input = 370;
+      double expected = 10;
+      assertEquals(expected, ArmSimulation.toSignedDegrees(input), 0.001);
+  }
+
+  @Test
+  public void toSignedDegreesTestWrapAroundNegativeDegrees() {
+      double input = -370;
+      double expected = -10;
+      assertEquals(expected, ArmSimulation.toSignedDegrees(input), 0.001);
+  }
 }
-

--- a/src/test/java/frc/robot/Simulation/CalcArmAngleTest.java
+++ b/src/test/java/frc/robot/Simulation/CalcArmAngleTest.java
@@ -9,60 +9,75 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import frc.robot.Constants;
 
 public class CalcArmAngleTest {
-    private CalcArmAngle m_calcArmAngle;
     private final double toleranceDegrees = 2;
     private final double toleranceRotations = 0.01;
+    private CalcArmAngle m_calcArmAngle;
+    private final double m_armHeightFromWinchToPivotPoint = 1;
+    private final double m_armLengthFromEdgeToPivot = 0.25;
 
     @BeforeEach
     public void setUp() {
+      m_calcArmAngle = new CalcArmAngle(m_armHeightFromWinchToPivotPoint, m_armLengthFromEdgeToPivot);
     }
 
     @Test
     public void ArmBeyondFullyUpShouldReturnError() {
-      double stringLen = (CalcArmAngle.m_armHeightFromWinchToPivotPoint - CalcArmAngle.m_armLengthFromEdgeToPivot);
+      double amountBeyondLimit = 0.0001;
+
+      double stringLen = (m_armHeightFromWinchToPivotPoint - m_armLengthFromEdgeToPivot - amountBeyondLimit);
       double expectedResult = -1;
 
-      assertTrue(CalcArmAngle.GetDegreesForStringLength(stringLen) == expectedResult);
+      assertTrue(m_calcArmAngle.GetDegreesForStringLength(stringLen) == expectedResult);
     }
 
     @Test
     public void ArmBeyondFullyDownShouldReturnError() {
-      double stringLen = (CalcArmAngle.m_armHeightFromWinchToPivotPoint + CalcArmAngle.m_armLengthFromEdgeToPivot);
+      double amountBeyondLimit = 0.0001;
+
+      double stringLen = (m_armHeightFromWinchToPivotPoint + m_armLengthFromEdgeToPivot + amountBeyondLimit);
       double expectedResult = -1;
     
-      assertTrue(CalcArmAngle.GetDegreesForStringLength(stringLen) == expectedResult);
+      assertTrue(m_calcArmAngle.GetDegreesForStringLength(stringLen) == expectedResult);
     }
 
     @Test
     public void ArmAtFullyUpShouldReturn90Degrees() {
-      double stringLen = (CalcArmAngle.m_armHeightFromWinchToPivotPoint - CalcArmAngle.m_armLengthFromEdgeToPivot) + 0.00001;
+      double stringLen = (m_armHeightFromWinchToPivotPoint - m_armLengthFromEdgeToPivot);
       double expectedResult = 90;
     
-      assertEquals(CalcArmAngle.GetDegreesForStringLength(stringLen), expectedResult, toleranceDegrees);
+      assertEquals(m_calcArmAngle.GetDegreesForStringLength(stringLen), expectedResult, toleranceDegrees);
     }
     
     @Test
     public void ArmAtFullyDownShouldReturn270Degrees() {
-      double stringLen = CalcArmAngle.m_armHeightFromWinchToPivotPoint + CalcArmAngle.m_armLengthFromEdgeToPivot - 0.00001;
+      double stringLen = m_armHeightFromWinchToPivotPoint + m_armLengthFromEdgeToPivot;
       double expectedResult = 270;
     
-      assertEquals(CalcArmAngle.GetDegreesForStringLength(stringLen), expectedResult, toleranceDegrees);
+      assertEquals(m_calcArmAngle.GetDegreesForStringLength(stringLen), expectedResult, toleranceDegrees);
     }
 
     @Test
     public void LevelArmShouldReturn0Degrees() {
-      double stringLen = CalcArmAngle.m_armHeightFromWinchToPivotPoint;
+      double stringLen = m_armHeightFromWinchToPivotPoint;
       double expectedResult = 0;
     
-      assertEquals(CalcArmAngle.GetDegreesForStringLength(stringLen), expectedResult, toleranceDegrees);
+      assertEquals(m_calcArmAngle.GetDegreesForStringLength(stringLen), expectedResult, toleranceDegrees);
     }
 
     @Test
     public void ArmAtFullyDownShouldReturnThreeQuartersRotations() {
-      double stringLen = CalcArmAngle.m_armHeightFromWinchToPivotPoint + CalcArmAngle.m_armLengthFromEdgeToPivot - 0.00001;
+      double stringLen = m_armHeightFromWinchToPivotPoint + m_armLengthFromEdgeToPivot;
       double expectedResult = 0.75;
     
-      assertEquals(CalcArmAngle.GetRotationsForStringLength(stringLen), expectedResult, toleranceRotations);
+      assertEquals(m_calcArmAngle.GetRotationsForStringLength(stringLen), expectedResult, toleranceRotations);
+    }
+
+    @Test
+    public void ArmAt45DegreesShouldSucceed() {
+      double stringLen = (m_armHeightFromWinchToPivotPoint - 0.17678);
+      double expectedResult = 45;
+
+      assertEquals(m_calcArmAngle.GetDegreesForStringLength(stringLen), expectedResult, toleranceDegrees);
     }
 }
 

--- a/src/test/java/frc/robot/Simulation/WinchSimulationTest.java
+++ b/src/test/java/frc/robot/Simulation/WinchSimulationTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class WinchSimulationTest {
     private final double m_SpoolDiameterMeters = 0.01; // (1 centimeter)
-    private final double m_TotalStringLenMeters = 5;
+    private final double m_TotalStringLenMeters = 5; 
     private final double m_InitialLenSpooled = 1;
     private final StringOrientation m_InitialStringOrientation = StringOrientation.BackOfRobot;
     private final boolean m_invertMotor = false;


### PR DESCRIPTION
Add $TODO to test soft limits


Try some different string lengths


Undo accidental change to winchsimtest test values


Move constants into constants file


Move constants to file


Fix DutyCycleEncoderSim2 to properly set absValue


Cleanup


Add one more test case to armSimulation


Changed CalcArmAngle to no longer  be static


Refactor ArmSimulation so I can pass in height param


Commenting out some unit tests that will be rewritten


Add $TODO


Pivot point on arm cant be 0, otherwise arm cant rotate


Fix one unit test to check that arm is level


Added unit tests for 45 degree angles on arm


Add more unit tests


Fix CalcArmAngle to no-longer use funny fudge factor


Cleanup


Cleanup


Cleanup tests


Add unit tests


Add unit tests


Cleanup


Support initial rotation of absolute encoder


Added toSignedDegrees with unit tests


Add unit test


Add arm limits


Cleanup


Cleanup


Fix ArmSimulation to work with offset


Arm breaks when it goes above or below limits


Fix constants