### PR TITLE
Created motor abstraction

### DIFF
--- a/src/main/java/frc/robot/simulation/framework/SimInputInterface.java
+++ b/src/main/java/frc/robot/simulation/framework/SimInputInterface.java
@@ -1,0 +1,8 @@
+package frc.robot.simulation.framework;
+
+/**
+ * Interface to get the input of a device. SimManager will call this method to get the input.
+ */
+public interface SimInputInterface<T> {
+  T getInput();
+}

--- a/src/main/java/frc/robot/simulation/framework/SimManagerBase.java
+++ b/src/main/java/frc/robot/simulation/framework/SimManagerBase.java
@@ -1,0 +1,52 @@
+package frc.robot.simulation.framework;
+
+import edu.wpi.first.wpilibj.RobotState;
+
+/**
+ * Partially implements SimManagerInterface.
+ */
+public abstract class SimManagerBase<InputT, OutputT>
+    implements SimManagerInterface<InputT, OutputT> {
+
+  private SimInputInterface<InputT> m_inputHandler = null;
+  private SimOutputInterface<OutputT> m_outputHandler = null;
+
+  /**
+   * Constructor.
+   */
+  public SimManagerBase() {
+  }
+
+  @Override
+  public final void setInputHandler(SimInputInterface<InputT> inputHandler) {
+    m_inputHandler = inputHandler;
+  }
+
+  @Override
+  public final void setOutputHandler(SimOutputInterface<OutputT> outputHandler) {
+    m_outputHandler = outputHandler;
+  }
+
+  private boolean isRobotEnabled() {
+    return RobotState.isEnabled();
+  }
+
+  // Must be implemented by derived class
+  protected abstract OutputT doSimulation(InputT input);
+
+  // The following method cannot be further overriden by derived class
+  @Override
+  public final void simulationPeriodic() {
+    // When Robot is disabled, the entire simulation freezes
+    if (isRobotEnabled() && m_inputHandler != null && m_outputHandler != null) {
+      // Step 1: Get the input from the input handler
+      InputT input = m_inputHandler.getInput();
+
+      // Step 2: Do simulation
+      OutputT result = this.doSimulation(input);
+
+      // Step 3: Write the output to the output handler
+      m_outputHandler.setOutput(result);
+    }
+  }
+}

--- a/src/main/java/frc/robot/simulation/framework/SimManagerInterface.java
+++ b/src/main/java/frc/robot/simulation/framework/SimManagerInterface.java
@@ -1,0 +1,14 @@
+package frc.robot.simulation.framework;
+
+/**
+ * Manages simulation of a particular device. It calls an input Supplier to periodically
+ * query inputs to device, and calls the output Consumer to set the new state of the device.
+ * It leverages a Model class to do the actual real-world simulation.
+ */
+public interface SimManagerInterface<InputT, OutputT> {
+  void setInputHandler(SimInputInterface<InputT> inputHandler);
+
+  void setOutputHandler(SimOutputInterface<OutputT> outputHandler);
+
+  void simulationPeriodic();
+}

--- a/src/main/java/frc/robot/simulation/framework/SimOutputInterface.java
+++ b/src/main/java/frc/robot/simulation/framework/SimOutputInterface.java
@@ -1,0 +1,8 @@
+package frc.robot.simulation.framework;
+
+/**
+ * Interface to set the output of a device. SimManager will call this method to set the output.
+ */
+public interface SimOutputInterface<T> {
+  void setOutput(T output);
+}

--- a/src/main/java/frc/robot/simulation/motor/MotorSimInput.java
+++ b/src/main/java/frc/robot/simulation/motor/MotorSimInput.java
@@ -1,0 +1,27 @@
+package frc.robot.simulation.motor;
+
+import com.revrobotics.CANSparkMax;
+import frc.robot.simulation.framework.SimInputInterface;
+
+/**
+ * Helper class to implement SimInputDoubleInterface.
+ */
+public class MotorSimInput implements SimInputInterface<Double> {
+  private CANSparkMax m_motorReal;
+
+  /**
+   * Constructor.
+   */
+  public MotorSimInput(CANSparkMax motorReal) {
+    if (motorReal == null) {
+      throw new IllegalArgumentException("motorReal cannot be null");
+    }
+
+    m_motorReal = motorReal;
+  }
+
+  @Override
+  public Double getInput() {
+    return m_motorReal.get();
+  }
+}

--- a/src/main/java/frc/robot/simulation/motor/MotorSimManager.java
+++ b/src/main/java/frc/robot/simulation/motor/MotorSimManager.java
@@ -1,0 +1,27 @@
+package frc.robot.simulation.motor;
+
+import frc.robot.simulation.framework.SimManagerBase;
+
+/**
+ * Simulation manager for a simple motor, AND an encoder that reads that motor position.
+ */
+public class MotorSimManager extends SimManagerBase<Double, Double> {
+  private final MotorSimModel m_model;
+
+  /**
+   * Constructor.
+   */
+  public MotorSimManager() {
+    m_model = new MotorSimModel();
+  }
+
+  @Override
+  protected Double doSimulation(Double motorPowerPercentage) {
+    // No need to call super, since it's abstract class and doesn't
+    // implement doSimulation()
+
+    double newEncoderPosition = m_model.updateMotorPosition(motorPowerPercentage);
+
+    return newEncoderPosition;
+  }
+}

--- a/src/main/java/frc/robot/simulation/motor/MotorSimModel.java
+++ b/src/main/java/frc/robot/simulation/motor/MotorSimModel.java
@@ -1,0 +1,43 @@
+package frc.robot.simulation.motor;
+
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.simulation.DCMotorSim;
+import frc.robot.Constants;
+
+/**
+ * Does the real-world simulation for the motor.
+ */
+public class MotorSimModel {
+  private final DCMotor m_extenderMotorModel;
+  private final DCMotorSim m_extenderMotorSim;
+
+  /**
+   * Constructor.
+   */
+  public MotorSimModel() {
+    // Model a NEO motor (or any other motor)
+    m_extenderMotorModel = DCMotor.getNEO(1); // 1 motor in the gearbox
+
+    // Create the motor simulation with motor model, gear ratio, and moment of
+    // inertia
+    double motorMomentInertia = 0.0005;
+    m_extenderMotorSim = new DCMotorSim(m_extenderMotorModel,
+        Constants.SimConstants.kextenderSimGearRatio, motorMomentInertia);
+  }
+
+  /**
+   * Runs 20ms simulation of the motor, and then returns the new encoder position (in Rotations).
+   */
+  public double updateMotorPosition(double motorPowerPercentage) {
+    // Calculate the input voltage for the motor
+    double inputVoltageVolts = motorPowerPercentage * 12.0;
+
+    // Update the motor simulation
+    m_extenderMotorSim.setInput(inputVoltageVolts);
+    m_extenderMotorSim.update(0.02);
+
+    // Update the Encoder based on the simulation - the units are "number of
+    // rotations"
+    return m_extenderMotorSim.getAngularPositionRotations();
+  }
+}

--- a/src/main/java/frc/robot/simulation/motor/MotorSimOutput.java
+++ b/src/main/java/frc/robot/simulation/motor/MotorSimOutput.java
@@ -1,0 +1,36 @@
+package frc.robot.simulation.motor;
+
+import frc.robot.simulation.framework.SimOutputInterface;
+import frc.robot.subsystems.RelativeEncoderSim;
+
+/**
+ * Helper class to implement OutputDoubleInterface.
+ */
+public class MotorSimOutput implements SimOutputInterface<Double> {
+  private final RelativeEncoderSim m_encoderRealWrapper;
+
+  /**
+   * Constructor. Note that the wrapper object (RelativeEncoderSim) is passed in,
+   * not the real object. This is because the simulation never writes to the
+   * real object (RelativeEncoder).
+   */
+  public MotorSimOutput(RelativeEncoderSim encoderRealWrapper) {
+    if (encoderRealWrapper == null) {
+      throw new IllegalArgumentException("encoderRealWrapper cannot be null");
+    }
+
+    m_encoderRealWrapper = encoderRealWrapper;
+    /*
+     * $TODO
+     * // Create a "sim" wrapper of the Robots real encoder. The sim wrapper
+     * // is later used to write to the real encoder
+     * m_encoderRealWrapper = new RelativeEncoderSim(encoderReal);
+     */
+  }
+
+  @Override
+  public void setOutput(Double output) {
+    // Sets the encoder position in rotations.
+    m_encoderRealWrapper.setPosition(output);
+  }
+}

--- a/src/main/java/frc/robot/subsystems/ArmSystemSimWithWidgets.java
+++ b/src/main/java/frc/robot/subsystems/ArmSystemSimWithWidgets.java
@@ -95,7 +95,7 @@ public class ArmSystemSimWithWidgets extends ArmSystemSim {
     // Extender motor power
     pos = m_defaultLayout.getWidgetPosition("Extender Motor Power");
     Shuffleboard.getTab("Simulation")
-        .addDouble("Extender Motor Power", () -> m_extenderMotorOutputPercentage)
+        .addDouble("Extender Motor Power", () -> m_armExtender.get())
         .withWidget(BuiltInWidgets.kNumberBar)
         .withProperties(Map.of("min", -1.0, "max", 1.0, "show text", false))
         .withPosition(pos.x, pos.y).withSize(pos.width, pos.height);


### PR DESCRIPTION
This checkin moves the motor simulation for the motor driving the arm's extender into a new abstraction.

That abstraction has 4 separate parts:
1) Input abstraction (in extender case, this reads the % power set on the real extender motor
2) Output abstraction (in extender case, this writes # of rotations on the extender motor to the encoder)
3) SimManager: This class manages the input and output abstractions
4) SimModel: This is the testable code that runs a "motor simulation".  In this case, we're just re-using a DCMotorSim to simulate a motor
